### PR TITLE
new: Add `setup-python` boolean input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ This GitHub Action allows users to quickly install and authenticate the Linode C
 
 See the [official Linode CLI repository](https://github.com/linode/linode-cli) for specific usage instructions.
 
+This GitHub Action is designed to run on Ubuntu-based runners and may not function as intended on other platforms.  
+
 ## Arguments
 
 This GitHub Action exposes the following arguments:
 
-| Name      | Required | Default | Description                                                                                                                                |
-|-----------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `token`   | No       | None    | The [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/) to authenticate the CLI with. |
-| `version` | No       | latest  | The version of the Linode CLI to install.                                                                                                  |
+| Name           | Required | Default | Description                                                                                                                                                                       |
+|----------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `token`        | No       | None    | The [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/) to authenticate the CLI with.                                        |
+| `version`      | No       | latest  | The version of the Linode CLI to install.                                                                                                                                         |
+| `setup-python` | No       | true    | If true, Python will automatically be installed on the runner. If false, users are expected to have a functioning Python installation on their runner before running this action. | 
 
 ## Getting Started
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   version:
     description: 'The Linode CLI version to install.'
     default: latest
+  setup-python:
+    description: 'If true, Python will automatically be installed on the runner.'
+    default: true
 runs:
   using: 'composite'
   steps:
@@ -19,6 +22,7 @@ runs:
 
     - name: Setup Python 3
       uses: actions/setup-python@v4.5.0
+      if: ${{ inputs.setup-python == 'true' }}
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
## 📝 Description

This change adds a `setup-python` input field that allows users to opt out of automatically installing Python on their GHA runner. Additionally, this change adds a note to `README.md` explaining that the project is currently only compatible with Ubuntu-based runners.