### PR TITLE
fix: Point release drafter workflow at the `v1` branch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main
+      - v1
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## 📝 Description

This change points the release drafting workflow at the `v1` branch rather than the `main` branch.
