### PR TITLE
new: Add `upgrade` option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
   test-optional-deps:
     runs-on: ubuntu-latest
-    name: Test the action with optional dependencies
+    name: Test the action with upgrades enabled
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,8 +51,6 @@ jobs:
         uses: ./
         with:
           token: "${{ secrets.LINODE_TOKEN }}"
-          optional-deps: true
-      - name: Assert optional dep installed
-        run: pip freeze | grep -q boto3
+          upgrade: true
       - name: Run an authenticated command
         run: linode-cli linodes ls > /dev/null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
   test-optional-deps:
     runs-on: ubuntu-latest
-    name: Test the action with upgrades enabled
+    name: Test the action with optional dependencies
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,6 +51,22 @@ jobs:
         uses: ./
         with:
           token: "${{ secrets.LINODE_TOKEN }}"
-          upgrade: true
+          optional-deps: true
+      - name: Assert optional dep installed
+        run: pip freeze | grep -q boto3
+      - name: Run an authenticated command
+        run: linode-cli linodes ls > /dev/null
+
+  test-no-upgrade:
+    runs-on: ubuntu-latest
+    name: Test the action with upgrade disabled
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install the Linode CLI
+        uses: ./
+        with:
+          token: "${{ secrets.LINODE_TOKEN }}"
+          upgrade: false
       - name: Run an authenticated command
         run: linode-cli linodes ls > /dev/null

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ This GitHub Action is designed to run on Ubuntu-based runners and may not functi
 
 This GitHub Action exposes the following arguments:
 
-| Name           | Required | Default | Description                                                                                                                                                                       |
-|----------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `token`        | No       | None    | The [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/) to authenticate the CLI with.                                        |
-| `version`      | No       | latest  | The version of the Linode CLI to install.                                                                                                                                         |
-| `setup-python` | No       | true    | If true, Python will automatically be installed on the runner. If false, users are expected to have a functioning Python installation on their runner before running this action. | 
+| Name            | Required | Default | Description                                                                                                                                                                       |
+|-----------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `token`         | No       | None    | The [Linode Personal Access Token](https://www.linode.com/docs/products/tools/api/guides/manage-api-tokens/) to authenticate the CLI with.                                        |
+| `version`       | No       | latest  | The version of the Linode CLI to install.                                                                                                                                         |
+| `setup-python`  | No       | true    | If true, Python will automatically be installed on the runner. If false, users are expected to have a functioning Python installation on their runner before running this action. | 
+| `upgrade`       | No       | true    | If true, Linode CLI and its dependencies will be automatically upgraded. (--upgrade)                                                                                              |
 
 ## Getting Started
 

--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,11 @@ runs:
       with:
         python-version: '3.x'
 
-    - name: Determine CLI install extension
-      id: determine_install_ext
+    - name: Determine CLI install arguments
+      id: determine_install_args
       shell: bash
       run: |
+        # Compute extension
         EXTENSION=""
 
         if [ "$OPTIONAL_DEPS" == "true" ]
@@ -49,12 +50,23 @@ runs:
         fi
         
         echo "version_extension=${EXTENSION}" >> $GITHUB_ENV
+        
+        # Compute args
+        ARGS=""
+        
+        if [ "$UPGRADE" == "true" ]
+        then
+          ARGS="${ARGS}--upgrade "
+        fi
+        
+        echo "pip_args=${ARGS}" >> $GITHUB_ENV
       env:
         VERSION: ${{ inputs.version }}
         OPTIONAL_DEPS: ${{ inputs.optional-deps }}
+        UPGRADE: ${{ inputs.upgrade }}
 
     - name: Install the Linode CLI
-      run: pip3 install ${{ inputs.upgrade && '--upgrade ' || '' }}linode-cli${{ env.version_extension }}
+      run: pip3 install ${{ env.pip_args }}linode-cli${{ env.version_extension }}
       shell: bash
 
     - name: Expose the Linode Token to the runner environment

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         OPTIONAL_DEPS: ${{ inputs.optional-deps }}
 
     - name: Install the Linode CLI
-      run: pip3 install ${{ inputs.upgrade && '' || '--upgrade ' }}linode-cli${{ env.version_extension }}
+      run: pip3 install ${{ inputs.upgrade && '--upgrade ' || '' }}linode-cli${{ env.version_extension }}
       shell: bash
 
     - name: Expose the Linode Token to the runner environment

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: true
   upgrade:
     description: 'If true, Linode CLI and its dependencies will be automatically upgraded. (--upgrade)'
-    default: false
+    default: true
 runs:
   using: 'composite'
   steps:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   setup-python:
     description: 'If true, Python will automatically be installed on the runner.'
     default: true
+  upgrade:
+    description: 'If true, Linode CLI and its dependencies will be automatically upgraded. (--upgrade)'
+    default: false
 runs:
   using: 'composite'
   steps:
@@ -51,7 +54,7 @@ runs:
         OPTIONAL_DEPS: ${{ inputs.optional-deps }}
 
     - name: Install the Linode CLI
-      run: pip3 install linode-cli${{ env.version_extension }}
+      run: pip3 install ${{ inputs.upgrade && '' || '--upgrade ' }}linode-cli${{ env.version_extension }}
       shell: bash
 
     - name: Expose the Linode Token to the runner environment


### PR DESCRIPTION
## 📝 Description

This change adds an `upgrade` option that allows users to automatically upgrade the Linode CLI and its dependencies using the `--upgrade` pip argument.
