### PR TITLE
Bump actions/setup-python to use Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       run: echo "::add-mask::${{ inputs.token }}"
 
     - name: Setup Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       if: ${{ inputs.setup-python == 'true' }}
       with:
         python-version: '3.x'


### PR DESCRIPTION
## 📝 Description

Addressing the GHA message: 

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


## ✔️ How to Test

Successful update removes the above message in workflows that use this action.
