### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./
         with:
           token: "${{ secrets.LINODE_TOKEN }}"
-          version: v5.35.0
+          version: v5.48.4
       - name: Run an authenticated command
         run: linode-cli linodes ls > /dev/null
 


### PR DESCRIPTION
Old CLI didn't work in Python 3.12.